### PR TITLE
fix(deps): Align react-dom and recharts with react 19 bump

### DIFF
--- a/crypto-planet/package-lock.json
+++ b/crypto-planet/package-lock.json
@@ -12,15 +12,15 @@
         "@tanstack/react-table": "^8.21.3",
         "lucide-react": "^1.8.0",
         "react": "^19.2.5",
-        "react-dom": "^18.3.1",
+        "react-dom": "^19.2.5",
         "react-router-dom": "^7.14.1",
-        "recharts": "^2.14.1"
+        "recharts": "^2.15.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
         "@types/babel__core": "^7.20.5",
         "@types/react": "^19.2.14",
-        "@types/react-dom": "^18.3.1",
+        "@types/react-dom": "^19.2.3",
         "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.5.0",
@@ -1643,13 +1643,13 @@
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/react-router": {
@@ -4098,16 +4098,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.5"
       }
     },
     "node_modules/react-is": {
@@ -4217,16 +4216,16 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.14.1.tgz",
-      "integrity": "sha512-xtWulflkA+/xu4/QClBdtZYN30dbvTHjxjkh5XTMrH/CQ3WGDDPHHa/LLKCbgoqz0z3UaSH2/blV1i6VNMeh1g==",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
       "license": "MIT",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",
         "lodash": "^4.17.21",
         "react-is": "^18.3.1",
-        "react-smooth": "^4.0.0",
+        "react-smooth": "^4.0.4",
         "recharts-scale": "^0.4.4",
         "tiny-invariant": "^1.3.1",
         "victory-vendor": "^36.6.8"
@@ -4235,8 +4234,8 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/recharts-scale": {
@@ -4391,13 +4390,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/crypto-planet/package.json
+++ b/crypto-planet/package.json
@@ -14,15 +14,15 @@
     "@tanstack/react-table": "^8.21.3",
     "lucide-react": "^1.8.0",
     "react": "^19.2.5",
-    "react-dom": "^18.3.1",
+    "react-dom": "^19.2.5",
     "react-router-dom": "^7.14.1",
-    "recharts": "^2.14.1"
+    "recharts": "^2.15.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",
     "@types/babel__core": "^7.20.5",
     "@types/react": "^19.2.14",
-    "@types/react-dom": "^18.3.1",
+    "@types/react-dom": "^19.2.3",
     "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.5.0",


### PR DESCRIPTION
## Context

PR #46 bumped `react` 18 → 19 and `@types/react` 18 → 19 but left three coupled packages behind, creating an inconsistent dependency graph on main:

- `react-dom` stayed at 18.3.1 — breaks peer-dep resolution with `react@19` on strict installs
- `@types/react-dom` stayed at 18.3.1 — misaligned with `@types/react@19`
- `recharts@2.14.1` declares peer `react@^16 || ^17 || ^18` — explicitly incompatible with React 19

Main currently installs only because Vercel falls back to `--legacy-peer-deps`, and the production build succeeds because `vite build` does not run `tsc`. Locally, `npm install` without flags fails with `ERESOLVE`.

## Changes

- `react-dom` 18.3.1 → 19.2.5 (matches `react`)
- `@types/react-dom` 18.3.1 → 19.2.3 (matches `@types/react`)
- `recharts` 2.14.1 → 2.15.4 (first 2.x release with explicit React 19 peer support; avoids the v3 migration effort, which is a separate discussion)

## Verification

- `npm install --package-lock-only` now resolves cleanly without peer-dep warnings
- Resolved versions confirmed in lockfile
- Vercel deploy will confirm runtime build

## Out of scope

There are pre-existing TypeScript errors in the project (`styleType` on `Button`, `selectType/selectSize` on `Select`, `inputType/inputSize` on `Input`) that surface when running `tsc`. These exist on main and are unrelated to the React 19 alignment. They should be addressed in a separate PR.