### PR TITLE
fix(vercel): Add SPA rewrite rule for client-side routing

### DIFF
--- a/crypto-planet/vercel.json
+++ b/crypto-planet/vercel.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## Problem

Direct access to routes like `/market`, `/portfolio`, `/login` returns 404 on production.

The app uses `BrowserRouter` with an index-route redirect (`<Navigate to="/market" replace />`). Without a catch-all rewrite on the host, Vercel tries to find a static file for every URL and returns 404 when it doesn't exist. Client-side navigation works because React Router intercepts clicks, but refreshes and deep links fail.

## Fix

Added `crypto-planet/vercel.json` with a catch-all rewrite as recommended by the [Vercel Vite docs](https://vercel.com/docs/frameworks/frontend/vite):

```json
{
  "$schema": "https://openapi.vercel.sh/vercel.json",
  "rewrites": [
    { "source": "/(.*)", "destination": "/index.html" }
  ]
}
```

This serves `index.html` for every request, letting React Router resolve the route on the client.

## Verification

The Vercel preview deploy of this PR should let us access `/market`, `/portfolio`, etc. directly without 404.