### PR TITLE
fix(react): Initialize auth state lazily to avoid cascading renders

### DIFF
--- a/crypto-planet/src/contexts/AuthContext.tsx
+++ b/crypto-planet/src/contexts/AuthContext.tsx
@@ -12,16 +12,12 @@ import {
 } from "../utils/storage/auth.storage.utils";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [user, setUser] = useState<IUser | null>(null);
+  // Lazy initializer reads localStorage exactly once before the first render,
+  // avoiding the cascading-render anti-pattern that an effect-based hydration
+  // would create. See: https://react.dev/reference/react/useState\#avoiding-recreating-the-initial-state
+  const [user, setUser] = useState<IUser | null>(() => getCurrentUser());
   const navigate = useNavigate();
   const users = getUsers();
-
-  useEffect(() => {
-    const savedUser = getCurrentUser();
-    if (savedUser) {
-      setUser(savedUser);
-    }
-  }, []);
 
   useEffect(() => {
     if (user && window.location.pathname === "/login") {


### PR DESCRIPTION
## Context

This is the first of three follow-up PRs to address `eslint-plugin-react-hooks` 7.x violations, building on the regression test infrastructure landed in #53.

## The bug

`AuthProvider` initialized `user` state with `null` and then hydrated from `localStorage` inside an empty-deps `useEffect`:

```ts
const [user, setUser] = useState<IUser | null>(null);

useEffect(() => {
  const savedUser = getCurrentUser();
  if (savedUser) {
    setUser(savedUser);
  }
}, []);
```

This is the classic *set-state-in-effect* anti-pattern. On every refresh, the provider renders once with `user=null` (showing anonymous UI), the effect runs after commit, `setUser` is called, and a second render happens with the hydrated user. The intermediate render is observable as a brief flash of the anonymous UI before the authenticated state appears.

## The fix

`useState` accepts an initializer function that runs exactly once, before the first render:

```ts
const [user, setUser] = useState<IUser | null>(() => getCurrentUser());
```

Reference: [React docs — Avoiding recreating the initial state](https://react.dev/reference/react/useState#avoiding-recreating-the-initial-state)

The hydration now happens synchronously before the first render, eliminating the cascade. The empty-deps effect is removed entirely; the second `useEffect` (for the `/login` redirect when authenticated) stays as is.

## Validation

- [x] `npm run lint` — `AuthContext.tsx` no longer flagged (3 errors remain in other files, addressed in follow-up PRs)
- [x] `npm run test:run` — 12/12 tests passing
- [x] `npm run build` — clean
- [x] No production behavior change (regression suite verifies hydration, login success/failure, logout)

## Next

- `feature/portfolio-derived-transactions`
- `feature/routes-hoist-public-route`
