### PR TITLE
fix(react): Derive portfolio transactions instead of mirroring in state

### DIFF
--- a/crypto-planet/src/pages/Portfolio/PortfolioPage.tsx
+++ b/crypto-planet/src/pages/Portfolio/PortfolioPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { IPortfolioTransaction } from "../../interfaces/portfolio.interfaces";
 import { randomId } from "../../utils/common/id.utils";
 import { useAuth } from "../../hooks/useAuth";
@@ -18,13 +18,29 @@ const PortfolioPage = () => {
   const { user } = useAuth();
   const [isPaymentModalOpen, setIsPaymentModalOpen] = useState(false);
   const [hideBalance, setHideBalance] = useState(false);
-  const [transactions, setTransactions] = useState<IPortfolioTransaction[]>(
-    user?.portfolio?.transactions || []
-  );
 
-  useEffect(() => {
-    setTransactions(user?.portfolio?.transactions || []);
-  }, [user?.portfolio?.transactions]);
+  // Optimistic-update slot: holds transactions added in this session that
+  // have not yet propagated back through the auth context. The slot is
+  // keyed on the source reference so that any external change (re-login,
+  // hydration) discards the local override automatically. This is the
+  // React-recommended pattern for adjusting state based on external
+  // changes during render, replacing the previous effect-based mirroring.
+  // See: https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
+  const sourceTransactions = user?.portfolio?.transactions;
+  const [optimisticTransactions, setOptimisticTransactions] = useState<
+    IPortfolioTransaction[] | null
+  >(null);
+  const [trackedSource, setTrackedSource] = useState(sourceTransactions);
+
+  if (sourceTransactions !== trackedSource) {
+    setTrackedSource(sourceTransactions);
+    setOptimisticTransactions(null);
+  }
+
+  const transactions = useMemo(
+    () => optimisticTransactions ?? sourceTransactions ?? [],
+    [optimisticTransactions, sourceTransactions]
+  );
 
   const portfolioTotals = useMemo(() => {
     return calculatePortfolioTotals(transactions);
@@ -43,10 +59,11 @@ const PortfolioPage = () => {
       status: "Succesful",
     };
 
-    setTransactions((prev) => [newTransaction, ...prev]);
+    const next = [newTransaction, ...transactions];
+    setOptimisticTransactions(next);
 
     if (user?.email) {
-      updateUserTransactions(user.email, [newTransaction, ...transactions]);
+      updateUserTransactions(user.email, next);
     }
 
     setIsPaymentModalOpen(false);


### PR DESCRIPTION
## Context

Second of three follow-up PRs to address `eslint-plugin-react-hooks` 7.x violations, building on the regression test infrastructure landed in #53 and the auth fix in #54.

## The bug

`PortfolioPage` held transactions in local state and synced it to `user.portfolio.transactions` via an effect:

```ts
const [transactions, setTransactions] = useState<IPortfolioTransaction[]>(
  user?.portfolio?.transactions || []
);

useEffect(() => {
  setTransactions(user?.portfolio?.transactions || []);
}, [user?.portfolio?.transactions]);
```

This is the classic *mirroring props in state* anti-pattern. The component renders with stale local state, then the effect runs after commit and triggers a second render with the synchronized state. Same cascading-renders cost as the auth case in #54, plus subtle bugs whenever the source updates faster than the effect schedules.

## The constraint

Removing the local state entirely would break the optimistic UI in `handleAddMoney`: when the user submits a payment, `updateUserTransactions` writes to `localStorage` but does **not** update the auth context's `user`, so the new transaction would not appear until something else triggered a context refresh.

## The fix

Split the responsibility cleanly:

- `sourceTransactions` reads directly from the auth context — single source of truth.
- `optimisticTransactions` is a separate slot for transactions added in the current session that have not yet propagated back through the context.
- A render-time check (`if (sourceTransactions !== trackedSource)`) discards the optimistic override whenever the source reference changes, so re-login or hydration always wins.

```ts
const sourceTransactions = user?.portfolio?.transactions;
const [optimisticTransactions, setOptimisticTransactions] = useState<
  IPortfolioTransaction[] | null
>(null);
const [trackedSource, setTrackedSource] = useState(sourceTransactions);

if (sourceTransactions !== trackedSource) {
  setTrackedSource(sourceTransactions);
  setOptimisticTransactions(null);
}

const transactions = useMemo(
  () => optimisticTransactions ?? sourceTransactions ?? [],
  [optimisticTransactions, sourceTransactions]
);
```

The `if`-then-`setState` during render is the [React-recommended pattern for adjusting state based on external changes](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes). React handles it as part of the same commit instead of scheduling a second render like an effect would.

The `useMemo` wrapping `transactions` keeps a stable reference for the downstream `portfolioTotals` memo when neither slot has changed.

## Future work

The optimistic slot exists because `updateUserTransactions` writes to `localStorage` without informing the auth context. A cleaner long-term refactor would expose a `refreshUser` (or similar) action through the context, eliminating the need for an optimistic mirror. That refactor is out of scope here — this PR is strictly about resolving the lint violation without changing observable behavior.

## Validation

- [x] `npm run lint` — `PortfolioPage.tsx` no longer flagged (2 errors remain in `routes/index.tsx`, addressed in the next PR)
- [x] `npm run test:run` — 12/12 tests passing (the `appends a transaction optimistically on payment submit` test verifies the optimistic-update path)
- [x] `npm run build` — clean

## Next

- `feature/routes-hoist-public-route` (final PR)
