### PR TITLE
fix(react): Hoist route guards to module scope

### DIFF
--- a/crypto-planet/src/routes/index.tsx
+++ b/crypto-planet/src/routes/index.tsx
@@ -12,24 +12,27 @@ const LoginPage = lazy(() => import("../pages/Login/LoginPage"));
 const RegisterPage = lazy(() => import("../pages/Register/RegisterPage"));
 const NotFoundPage = lazy(() => import("../pages/Error/NotFoundPage"));
 
-interface PrivateRouteProps {
+interface GuardProps {
   children: React.ReactNode;
 }
 
-const PrivateRoute = ({ children }: PrivateRouteProps) => {
+// Both guards live at module scope so React keeps a stable component identity
+// across renders. Declaring them inside Router would create a new component
+// type on every render, forcing React to unmount and remount the subtree,
+// resetting any state the children hold.
+const PrivateRoute = ({ children }: GuardProps) => {
   const { isAuthenticated } = useAuth();
   if (!isAuthenticated) return <Navigate to={"/login"} replace />;
   return <>{children}</>;
 };
 
-export function Router() {
+const PublicRoute = ({ children }: GuardProps) => {
   const { isAuthenticated } = useAuth();
+  if (isAuthenticated) return <Navigate to={"/portfolio"} replace />;
+  return <>{children}</>;
+};
 
-  const PublicRoute = ({ children }: { children: React.ReactNode }) => {
-    if (isAuthenticated) return <Navigate to={"/portfolio"} replace />;
-    return <>{children}</>;
-  };
-
+export function Router() {
   return (
     <Routes>
       <Route path="/" element={<DefaultLayout />}>


### PR DESCRIPTION
## Context

Third and final follow-up PR to address `eslint-plugin-react-hooks` 7.x violations, completing the cycle started in #53 (test infrastructure), #54 (auth) and #55 (portfolio).

## The bug

`PublicRoute` was declared inside the `Router` function body:

```tsx
export function Router() {
  const { isAuthenticated } = useAuth();

  const PublicRoute = ({ children }: { children: React.ReactNode }) => {
    if (isAuthenticated) return <Navigate to="/portfolio" replace />;
    return <>{children}</>;
  };

  return (<Routes>...</Routes>);
}
```

This creates a new `PublicRoute` function reference on every render of `Router`. React identifies components by referential identity — different function, different component type. So the entire guarded subtree is unmounted and remounted on each parent render, resetting state and re-running effects. React-hooks 7.x flags this with the `static-components` rule.

Note that `PrivateRoute` was already at module scope and working correctly — `PublicRoute` was an inconsistency.

## The fix

Moved `PublicRoute` to module scope, alongside `PrivateRoute`. Both now call `useAuth()` internally instead of capturing the value via closure. This keeps the component identity stable across renders.

```tsx
interface GuardProps {
  children: React.ReactNode;
}

const PrivateRoute = ({ children }: GuardProps) => {
  const { isAuthenticated } = useAuth();
  if (!isAuthenticated) return <Navigate to="/login" replace />;
  return <>{children}</>;
};

const PublicRoute = ({ children }: GuardProps) => {
  const { isAuthenticated } = useAuth();
  if (isAuthenticated) return <Navigate to="/portfolio" replace />;
  return <>{children}</>;
};
```

## Validation

- [x] `npm run lint` — 0 errors (down from 4 across the three fixes). 2 warnings remain for `incompatible-library` in TanStack Table call sites — not bugs, React Compiler optimization skipped by design.
- [x] `npm run test:run` — 12/12 tests passing, including all four route-guard behavior tests from #53.
- [x] `npm run build` — clean.

## Remaining incompatible-library warnings

The two warnings in `MarketTable` and `PortfolioTable` come from TanStack Table's `useReactTable()` returning functions that React Compiler cannot memoize safely. The compiler skips optimization of these components, which is expected and documented behavior. Runtime is correct; no refactor needed.

## Series summary

Cycle completed:

- #53 chore(test): Vitest infrastructure + 12 regression tests
- #54 fix(react): AuthContext lazy initializer
- #55 fix(react): PortfolioPage derived transactions
- This PR — fix(react): Route guards hoisted to module scope

All four react-hooks 7.x errors resolved without changing observable behavior (regression suite preserved throughout).
