### PR TITLE
chore: Add root .gitignore generated by Vercel CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*.local


### PR DESCRIPTION
Adds the root .gitignore that was generated by the Vercel CLI when it
detected the repository root had no ignore rules. Patterns:

- .vercel: ignores the local Vercel project metadata (.vercel/ directory)
- .env*.local: ignores root-level local environment files

Both patterns are already covered inside crypto-planet/.gitignore for the
subproject scope; this file scopes them at the monorepo root, where Vercel
CLI artifacts actually appear.