### PR TITLE
chore(ci): Target develop branch in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,9 @@
-# Dependabot configuration
-# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
   # Frontend (React + Vite + TypeScript)
   - package-ecosystem: "npm"
     directory: "/crypto-planet"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -21,6 +19,7 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
Adds target-branch: develop to npm and github-actions ecosystems so Dependabot PRs land on develop instead of main. Aligns with Gitflow.