### PR TITLE
chore(ci): Add Dependabot cooldown for supply-chain safety

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,14 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
     groups:
       frontend-minor-patch:
         update-types: ["minor", "patch"]
-
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -27,3 +31,8 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30


### PR DESCRIPTION
## Supply-chain hardening

Adds a `cooldown` block to both Dependabot update configs (npm, github-actions), delaying version-update PRs until a release has aged.

### Cooldown values
- `default-days`: 7 (floor for anything outside semver categories)
- `semver-patch-days`: 7
- `semver-minor-days`: 14
- `semver-major-days`: 30

### Rationale
Most supply-chain compromises (malicious publish, compromised maintainer account) are detected and yanked within hours to a few days. Aging releases before adoption shrinks exposure to that window. Majors wait longest (30d) since they carry both breaking-change and higher supply-chain risk; patches wait 7d to stay responsive.

### Scope
Cooldown applies only to version updates. Security updates still bypass the cooldown and arrive immediately, so CVE fixes are not delayed.