### PR TITLE
fix(ci): Add Dependabot cooldown to activate config on default branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,14 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
     groups:
       frontend-minor-patch:
         update-types: ["minor", "patch"]
-
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -27,3 +31,8 @@ updates:
       include: "scope"
     labels:
       - "dependencies"
+    cooldown:
+      default-days: 7
+      semver-patch-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30


### PR DESCRIPTION
## Activate cooldown on default branch

The cooldown config was merged via #74 but only into `develop`. Since Dependabot reads its configuration from the default branch (`main`), the cooldown was never actually active. This brings the cooldown blocks to `main`.

### Cooldown values
- `default-days`: 7
- `semver-patch-days`: 7
- `semver-minor-days`: 14
- `semver-major-days`: 30

### Note
The `dependabot.yml` now matches the version already on `develop`, so no conflict will arise on a future merge between the branches. Cooldown applies only to version updates; security updates remain immediate.